### PR TITLE
Add config file to ease porting to different boards

### DIFF
--- a/cc25xx_config.py
+++ b/cc25xx_config.py
@@ -1,0 +1,12 @@
+import board
+
+# Neopixel output port, used for debugging output
+# Set to None to disable Neopixel support
+PIN_NEOPIXEL = board.neopixel
+
+# Pin numbers should be consecutive
+PIN_DD  = board.GP27
+PIN_DC  = board.GP28
+PIN_RST = board.GP29
+
+PIO_FREQUENCY = 25_000_000

--- a/cc25xx_proto.py
+++ b/cc25xx_proto.py
@@ -3,16 +3,17 @@ import adafruit_pioasm
 from array import array
 import board
 import time
+import cc25xx_config
 
 # seems like RP2040 cannot sample fast enough
 # Maybe with second input-only pin on DD reads will be more reliable
 # 25 MHz clock   --  ~8 Mbps bitrate
-pio_frequency = 25_000_000
+pio_frequency = cc25xx_config.PIO_FREQUENCY
 
-pinDD  = board.GP27
+pinDD  = cc25xx_config.PIN_DD
 # DC and RST must be consecutive because they are set by pio side-set
-pinDC  = board.GP28
-pinRST = board.GP29
+pinDC  = cc25xx_config.PIN_DC
+pinRST = cc25xx_config.PIN_RST
 
 
 


### PR DESCRIPTION
I added an extra Python file which should contain everything a user needs to use this on another RP2040-based board. I also factored out all Neopixel changes to a separate function so it can be disabled with one `if` (though I don't have access to one, so that code is currently untested).